### PR TITLE
修改 html.img 渲染步骤

### DIFF
--- a/modules/html/__init__.py
+++ b/modules/html/__init__.py
@@ -1,12 +1,8 @@
 from flask_restful import Resource, reqparse
-from loguru import logger as l
-from playwright.sync_api import Playwright, sync_playwright
-import os
+from playwright.sync_api import sync_playwright
 import mistletoe
-import random
 import base64
-from PIL import Image
-import io
+
 
 resources = [
     {"name":"markdown","args":"/markdown"},
@@ -25,13 +21,9 @@ class img(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('html', location='form', type=str)
         parser.add_argument('github-markdown', location='form', type=str)
-        parser.add_argument('timeout', location='form', type=str)
+        parser.add_argument('timeout', location='form', type=int)
         args = parser.parse_args()
         args['html'] = args['html'].replace("\\n","")
-        try:
-            args['timeout'] = int(args['timeout'])
-        except:
-            pass
         if args['github-markdown'] is None:
             html = args['html']
         else:
@@ -40,15 +32,10 @@ class img(Resource):
             browser = playwright.chromium.launch(headless=True)
             page = browser.new_page()
             page.set_content(html)
-            fpath = os.path.join(os.getcwd(),"cache","".join(random.choices("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", k=20))+".png")
             if args['github-markdown'] is None:
-                page.screenshot(path=fpath,full_page=True,timeout=args['timeout'])
+                rawBytes = page.screenshot(type="png", full_page=True,timeout=args['timeout'])
             else:
                 element_handle = page.query_selector("//article[@id='md']")
-                element_handle.screenshot(path=fpath,timeout=args['timeout'])
+                rawBytes = element_handle.screenshot(type="png",timeout=args['timeout'])
             browser.close()
-        img = Image.open(fpath)
-        rawBytes = io.BytesIO()
-        img.save(rawBytes, "PNG")
-        rawBytes.seek(0)
-        return {"message":"success","image_base64":base64.b64encode(rawBytes.read()).decode()}
+        return {"message":"success","image_base64":base64.b64encode(rawBytes).decode()}


### PR DESCRIPTION
修改 html.img 的渲染步骤，跳过 PIL 读取并转换图片，直接由 playwright 返回 bytes
